### PR TITLE
Ensure door opener shuts off again

### DIFF
--- a/esphome/klingel_hass.yaml
+++ b/esphome/klingel_hass.yaml
@@ -79,7 +79,11 @@ switch:
     pin: D7
   - platform: gpio
     name: "RelayA"
+    id: relayA
     pin: D6
+    on_turn_on:
+      - delay: 10s
+      - switch.turn_off: relayA
   - platform: gpio
     name: "RelayB"
     pin: D5


### PR DESCRIPTION
We've had an incident, where the homeassistant script didn't complete or something along those lines, resulting in the door opener running for an hour or so. This change makes sure that the ESP itself turns off that pin after 10 seconds.

I'm not sure whether it makes sense to upstream it like this, considering that the relays are kind of general purpose right now, but it might still make sense.