### PR TITLE
filter bell input

### DIFF
--- a/esphome/klingel_hass.yaml
+++ b/esphome/klingel_hass.yaml
@@ -48,6 +48,8 @@ binary_sensor:
         mode: INPUT_PULLUP
         inverted: True
     name: "bell"
+    filters:
+      - delayed_off: 100ms
     on_press: # auto mute feature
       then:
         - if:


### PR DESCRIPTION
Our bells voltage was alternating in a way that caused the ESP to register this as repeatedly turning the bell on and off for as long as the bell was ringing. This filters the input, so that it has to stay of for at least a tenth of a second to register as two separate rings.